### PR TITLE
Configurable lookup task retry

### DIFF
--- a/scheduler/mesos/args.go
+++ b/scheduler/mesos/args.go
@@ -23,5 +23,5 @@ func Args() []scheduler.Args {
 }
 
 func newMesosScheduler() (scheduler.Scheduler, error) {
-	return NewMesosScheduler(viper.GetString("mesos-master"))
+	return NewMesosScheduler(viper.GetString("mesos-master"), viper.GetDuration("task-grace"))
 }

--- a/scheduler/mesos/mesos.go
+++ b/scheduler/mesos/mesos.go
@@ -136,11 +136,11 @@ func (m *mesosScheduler) LookupTask(taskId string) (scheduler.Task, error) {
 		time.Sleep((500 + 250*i) * time.Millisecond)
 		mesosTask, framework, slaveHost, err = m.getMesosTask(taskId)
 	}
-	runningTime := time.Unix(0, 0)
-	if len(mesosTask.Statuses) > 0 {
-		// https://github.com/apache/mesos/blob/a61074586d778d432ba991701c9c4de9459db897/src/webui/master/static/js/controllers.js#L148
-		runningTime = time.Unix(0, int64(mesosTask.Statuses[0].Timestamp*1000000000))
+	if len(mesosTask.Statuses) == 0 {
+		return nil, scheduler.ErrTaskStatusNotFound
 	}
+	// https://github.com/apache/mesos/blob/a61074586d778d432ba991701c9c4de9459db897/src/webui/master/static/js/controllers.js#L148
+	runningTime := time.Unix(0, int64(mesosTask.Statuses[0].Timestamp*1000000000))
 
 	var ip net.IP
 	if err == nil {

--- a/scheduler/mesos/mesos.go
+++ b/scheduler/mesos/mesos.go
@@ -130,6 +130,7 @@ func NewMesosScheduler(master string) (scheduler.Scheduler, error) {
 }
 
 func (m *mesosScheduler) LookupTask(taskId string) (scheduler.Task, error) {
+	// Allow for configurable timeout here
 	mesosTask, framework, slaveHost, err := m.getMesosTask(taskId)
 	for i := time.Duration(0); i < 3 && err == nil && len(mesosTask.Statuses) == 0; i++ {
 		time.Sleep((500 + 250*i) * time.Millisecond)

--- a/scheduler/mesos/mesos_test.go
+++ b/scheduler/mesos/mesos_test.go
@@ -3,6 +3,7 @@ package mesos
 import (
 	"os"
 	"testing"
+	"time"
 )
 
 var testMesosMaster = os.Getenv("MESOS_MASTER")
@@ -11,7 +12,7 @@ func TestGetMesos(t *testing.T) {
 	if len(testMesosMaster) == 0 {
 		t.Skip()
 	} else {
-		if _, err := NewMesosScheduler(testMesosMaster); err != nil {
+		if _, err := NewMesosScheduler(testMesosMaster, time.Minute); err != nil {
 			t.Fatalf("Failed to get mesos masters: %v", err)
 		}
 	}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -7,6 +7,7 @@ import (
 )
 
 var ErrTaskNotFound = errors.New("Task not found.")
+var ErrTaskStatusNotFound = errors.New("Task status not found.")
 
 type Task interface {
 	Id() string


### PR DESCRIPTION
In the event there is a delay between a task starting and the first status propagating to the mesos state endpoint, the `LookupTask` should retry up to the configured `task-grace` period but currently only retries for a few seconds.  If this happens, vault gatekeeper returns a `"This task has been running too long to request a token."` error since the default start time of 0 is never overwritten by a status timestamp.

This PR passes the configured duration to the mesosScheduler struct and extends the retry logic to continue until that is exceeded.  If exceeded and still no status information exists, return a more specific `ErrTaskStatusNotFound = errors.New("Task status not found.")` error.